### PR TITLE
Перенесен файл service_registry.yaml из dzo-core в seaf-core\entities…

### DIFF
--- a/entities/app/components/root.yaml
+++ b/entities/app/components/root.yaml
@@ -1,3 +1,4 @@
 imports:
   - components.yaml
   - contexts.yaml
+  - service_registry.yaml

--- a/entities/app/components/service_registry.yaml
+++ b/entities/app/components/service_registry.yaml
@@ -1,0 +1,25 @@
+entities:
+  components:
+    presentations:
+      seaf.app.services.registry:
+        type: table
+        headers:
+          - value: id
+            text: Идентификатор
+            link: link
+          - value: title
+            text: Наименование
+            align: left
+            link: link
+          - value: description
+            text: Описание
+            align: left
+        source: >
+          (
+             [$.components.$spread()[*.type="service"].{
+                  "id": $keys()[0],
+                  "link": "/entities/components/blank?dh-component-id=" & $keys()[0],
+                  "title": *.title,
+                  "description": *.description
+              }]
+          )


### PR DESCRIPTION
Перенесен файл service_registry.yaml из dzo-core в seaf-core\entities\app\components для корректного формирования таблицы прикладных сервисов без подключения dzo-core (без зависимости).

(cherry picked from commit fbc7fe3a44c02abf2ef83fb849295ebb7607d76b)